### PR TITLE
fix: remove top level await

### DIFF
--- a/src/lib/services/journal/wrapper.ts
+++ b/src/lib/services/journal/wrapper.ts
@@ -3,14 +3,16 @@ import type { CachedSearchResult } from '$lib/models/cachedSearch';
 import type { ActiveJournalEntry, JournalSearchState } from '$lib/models/journal';
 import { wrap } from 'comlink';
 
-const worker: any = browser ? wrap(new (await import('./worker?worker')).default()) : undefined;
+const worker: any = browser
+  ? import('./worker?worker').then((w) => wrap(new w.default()))
+  : undefined;
 
 export async function sortOrSearch(
   entries: Array<ActiveJournalEntry>,
   search: JournalSearchState,
 ): Promise<CachedSearchResult<ActiveJournalEntry>> {
   if (browser) {
-    return worker.sortOrSearch(entries, search);
+    return (await worker).sortOrSearch(entries, search);
   } else {
     return { data: [], totalEntries: 0 };
   }
@@ -18,7 +20,7 @@ export async function sortOrSearch(
 
 export async function loadPage(index: number, count: number): Promise<Array<ActiveJournalEntry>> {
   if (browser) {
-    return worker.loadPage(index, count);
+    return (await worker).loadPage(index, count);
   } else {
     return [];
   }

--- a/src/lib/services/journal/wrapper.ts
+++ b/src/lib/services/journal/wrapper.ts
@@ -3,6 +3,10 @@ import type { CachedSearchResult } from '$lib/models/cachedSearch';
 import type { ActiveJournalEntry, JournalSearchState } from '$lib/models/journal';
 import { wrap } from 'comlink';
 
+/**
+ * Don't use top level await as it is not supported in Safari yet (as of March 2026).
+ * https://caniuse.com/wf-top-level-await
+ */
 const worker: any = browser
   ? import('./worker?worker').then((w) => wrap(new w.default()))
   : undefined;

--- a/src/lib/services/myCoffees/search/wrapper.ts
+++ b/src/lib/services/myCoffees/search/wrapper.ts
@@ -3,6 +3,10 @@ import type { CachedSearchResult } from '$lib/models/cachedSearch';
 import type { ActiveCoffeeEntry, MyCoffeesSearchState } from '$lib/models/myCoffees';
 import { wrap } from 'comlink';
 
+/**
+ * Don't use top level await as it is not supported in Safari yet (as of March 2026).
+ * https://caniuse.com/wf-top-level-await
+ */
 const worker: any = browser
   ? import('./worker?worker').then((w) => wrap(new w.default()))
   : undefined;

--- a/src/lib/services/myCoffees/search/wrapper.ts
+++ b/src/lib/services/myCoffees/search/wrapper.ts
@@ -3,14 +3,16 @@ import type { CachedSearchResult } from '$lib/models/cachedSearch';
 import type { ActiveCoffeeEntry, MyCoffeesSearchState } from '$lib/models/myCoffees';
 import { wrap } from 'comlink';
 
-const worker: any = browser ? wrap(new (await import('./worker?worker')).default()) : undefined;
+const worker: any = browser
+  ? import('./worker?worker').then((w) => wrap(new w.default()))
+  : undefined;
 
 export async function sortOrSearch(
   entries: Array<ActiveCoffeeEntry>,
   search: MyCoffeesSearchState,
 ): Promise<CachedSearchResult<ActiveCoffeeEntry>> {
   if (browser) {
-    return worker.sortOrSearch(entries, search);
+    return (await worker).sortOrSearch(entries, search);
   } else {
     return { data: [], totalEntries: 0 };
   }
@@ -21,7 +23,7 @@ export async function quickSearch(
   filter?: string,
 ): Promise<Array<ActiveCoffeeEntry>> {
   if (browser) {
-    return worker.quickSearch(entries, filter);
+    return (await worker).quickSearch(entries, filter);
   } else {
     return [];
   }
@@ -29,7 +31,7 @@ export async function quickSearch(
 
 export async function loadPage(index: number, count: number): Promise<Array<ActiveCoffeeEntry>> {
   if (browser) {
-    return worker.loadPage(index, count);
+    return (await worker).loadPage(index, count);
   } else {
     return [];
   }

--- a/src/lib/services/sync/nextcloud.ts
+++ b/src/lib/services/sync/nextcloud.ts
@@ -31,6 +31,10 @@ import { isValid } from '../validation/validation';
 
 const SYNC_DIR = 'CoffeePal';
 
+/**
+ * Don't use top level await as it is not supported in Safari yet (as of March 2026).
+ * https://caniuse.com/wf-top-level-await
+ */
 const createClient = (async () => (await import('webdav')).createClient)();
 
 export class NextcloudLoginClient {

--- a/src/lib/services/sync/nextcloud.ts
+++ b/src/lib/services/sync/nextcloud.ts
@@ -31,7 +31,7 @@ import { isValid } from '../validation/validation';
 
 const SYNC_DIR = 'CoffeePal';
 
-const { createClient } = await import('webdav');
+const createClient = (async () => (await import('webdav')).createClient)();
 
 export class NextcloudLoginClient {
   /* https://docs.nextcloud.com/server/latest/developer_manual/client_apis/LoginFlow/index.html#login-flow-v2 */
@@ -100,7 +100,7 @@ export class NextcloudSyncClient implements SyncClient {
   public async init(): Promise<void> {
     const webdavUrl = new URL(this.connection.server.url);
     webdavUrl.pathname = '/remote.php/dav';
-    this.client = createClient(webdavUrl.href, this.connection.credentials);
+    this.client = (await createClient)(webdavUrl.href, this.connection.credentials);
     await this.initSyncDir();
   }
 


### PR DESCRIPTION
Remove all top level await uses because Safari on iOS does not yet support this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Deferred initialization of background services to use lazy loading, improving startup behavior and avoiding Safari-specific issues.
  * Adjusted internal service invocation to await readiness before use.
  * No changes to public APIs or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->